### PR TITLE
Wrap NETWORK_ADDRESS in a try/catch to avoid NPE

### DIFF
--- a/src/main/java/com/inkysea/vmware/vra/jenkins/plugin/model/Deployment.java
+++ b/src/main/java/com/inkysea/vmware/vra/jenkins/plugin/model/Deployment.java
@@ -243,7 +243,10 @@ public class Deployment {
                     machineDataList.add(jsonData.getAsJsonObject().get("Component").getAsString());
                     machineDataList.add(content.getAsJsonObject().get("name").getAsString());
                     machineDataList.add(jsonNetworkData.getAsJsonObject().get("NETWORK_NAME").getAsString());
-                    machineDataList.add(jsonNetworkData.getAsJsonObject().get("NETWORK_ADDRESS").getAsString());
+                    try {
+                        machineDataList.add(jsonNetworkData.getAsJsonObject().get("NETWORK_ADDRESS").getAsString());
+                    } catch (NullPointerException exception) {
+                    }
 
                     machineList.add(machineDataList);
 


### PR DESCRIPTION
When a machine in a deployment has a DHCP network (no NETWORK_ADDRESS), a NPE would occur.  The deployment would succeed but Jenkins would mark a failure.
This should prevent it.